### PR TITLE
run: restore the .exe suffix on windows sn cli builds

### DIFF
--- a/all/run.sh
+++ b/all/run.sh
@@ -1078,17 +1078,23 @@ sn_cli_release () {
     local src="$BUILD_HOME/sn${GO_MOD_SUFFIX}/cli/$pkg"
     local out="$src/build"
     rm -rf "$out" || return 1
-    local osarch os arch gomips
+    local osarch os arch gomips ext
     for osarch in "$@"; do
         os="${osarch%/*}"
         arch="${osarch#*/}"
         gomips=""
         case "$arch" in mips*) gomips="GOMIPS=softfloat" ;; esac
+        # `go build -o <file>` writes the name verbatim -- it only appends the
+        # platform exe suffix when it derives the name itself (`-o <dir>/`). The
+        # binary is renamed here (cli/miner -> provider), so the suffix has to be
+        # added by hand or windows ships an extensionless, unrunnable file.
+        ext=""
+        case "$os" in windows) ext=".exe" ;; esac
         (cd "$src" &&
             env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" $gomips \
                 go build -trimpath \
                 -ldflags "-w -s -X main.Version=${WARP_VERSION}" \
-                -o "$out/$os/$arch/$binary" .) || return 1
+                -o "$out/$os/$arch/$binary$ext" .) || return 1
     done
     (cd "$out" && COPYFILE_DISABLE=1 tar -czf "$binary.tar.gz" */)
 }


### PR DESCRIPTION
## Problem

`urnetwork-provider-*.tar.gz` ships its Windows binaries without a `.exe` extension:

```
$ curl -sL .../urnetwork-provider-2026.7.22-999364020.tar.gz | tar -tz | grep windows
windows/amd64/provider
windows/arm64/provider
```

`.exe` is the contract the consumers were written against. `connect/scripts/Provider_Install_Win32.ps1:171-181`:

```powershell
$BinarySuffix = switch ($OS) {
    "linux"   { "" }
    "windows" { ".exe" }
}
$BinaryPath = Join-Path $ExtractPath -ChildPath "$OS/$Arch/provider$BinarySuffix"
if (-not (Test-Path $BinaryPath)) {
    Write-Error "File $BinaryPath not found: The downloaded archive file is most likely corrupt"
    exit 1
}
```

Against a current tarball that `Test-Path` fails and the install aborts with a misleading "archive is most likely corrupt".

## Cause

`go build -o <file>` writes the name verbatim. It only appends the platform exe suffix when it derives the output name itself — `-o` with a trailing separator, or naming an existing directory (`cmd/go/internal/work/build.go`: `p.Target = filepath.Join(cfg.BuildO, p.DefaultExecName()); p.Target += cfg.ExeSuffix`).

The old `connect/provider/Makefile` used the directory form:

```
go build ... -o build/windows/amd64/
```

`sn_cli_release`, added in c568777 to rebuild the provider out of `sn/cli/miner`, uses an explicit path:

```
go build ... -o "$out/$os/$arch/$binary"
```

The explicit form is necessary here — the binary is renamed on the way out (`cli/miner` → `provider`) and the directory form derives the name from the package, so it would emit `miner.exe` (measured, see T2 below). But the suffix was lost with it.

## Evidence

| release | built by | windows entries |
| --- | --- | --- |
| `v2026.7.2-982300760` | `connect/provider/Makefile` | `windows/{amd64,arm64}/provider.exe` |
| `v2026.7.22-999364020` | `sn_cli_release` | `windows/{amd64,arm64}/provider` |

Timeline:

- a4dafda (Jul 5) — *build: remove provider during sn transition*; provider asset drops out of releases entirely
- releases Jul 5–15 carry no provider asset
- c568777 (Jul 15) — adds `sn_cli_release`. The asset returns at `v2026.7.15-993810200`, now extensionless, though that tag and several after it are drafts; the first **published** release carrying the broken artifact is `v2026.7.21-998357170` (Jul 21)
- the `-o` line is byte-identical from c568777 through a5e3e1c despite 11 intervening commits to `run.sh`, so every release since is affected

## Blast radius

Not as wide as it looks today, but it will be:

- The install scripts read **connect's** releases, not this repo's (`$GithubURLBase = "https://api.github.com/repos/urnetwork/connect"` — `Provider_Install_Win32.ps1:127`, `urnet-tools.ps1:82`). connect's latest is `v2026.3.23-895075980` from March, built by the old directory-form Makefile, so those installers are still pulling a good artifact. They break the moment a connect release is cut from current build output.
- Broken **now** is anyone taking the tarball from this repo directly, which `docs/router/testing-notes.md:9` tells them to do.

Restoring `.exe` is the un-break, not a behaviour change: every Windows consumer I could find already expects it (`Provider_Install_Win32.ps1`, `urnet-tools.ps1`, `Provider_Uninstall_Win32.ps1`), and none was written or patched after Jul 15.

## Fix

Append `.exe` explicitly when `GOOS=windows`.

## Test

Measured with go1.26.5 windows/amd64 against a package laid out like `sn/cli/miner`, using `run.sh`'s exact flags (`GOEXPERIMENT=greenteagc CGO_ENABLED=0 ... -trimpath -ldflags "-w -s -X main.Version=..."`). `GOEXPERIMENT=greenteagc` is accepted by 1.26.5.

| | `-o` form | output |
| --- | --- | --- |
| T1 | `.../windows/amd64/provider` (current) | `provider` |
| T2 | `.../windows/amd64/` (old Makefile) | **`miner.exe`** — suffix added, name derived from the package |
| T3 | `.../windows/amd64` (existing dir, no slash) | `miner.exe` |
| T4 | `.../windows/amd64/provider.exe` (this PR) | `provider.exe` |
| T5 | linux/amd64, darwin/arm64 with this PR | `provider`, `provider` — non-windows unaffected |

T2 is the reason the directory form can't just be restored: it yields `miner.exe`, not `provider.exe`.

Running the full patched loop and the existing `tar -czf "$binary.tar.gz" */` step reproduces the pre-regression layout exactly:

```
darwin/arm64/provider
linux/amd64/provider
windows/amd64/provider.exe
windows/arm64/provider.exe
```

Both binaries are valid `PE32+ executable ... x86-64`; the extensionless one is not corrupt, just unusable. Launch behaviour on Windows 11 / PowerShell 5.1, using the real built binaries:

| invocation | extensionless | `.exe` |
| --- | --- | --- |
| `cmd.exe`, explicit full path | `is not recognized as an internal or external command` | runs |
| PowerShell `&`, in a pipeline | throws `Cannot run a document in the middle of a pipeline` | runs |
| PowerShell `&`, not in a pipeline | **returns normally without executing**, `$LASTEXITCODE` untouched | runs |
| `Start-Process -FilePath` | runs, exit 0 | runs |

So it isn't wholly unexecutable — `Start-Process` works, and `Get-Command` resolves it as an `Application` — but the silent no-op under `&` is the nastiest of these. Replaying the installer's `Test-Path` guard against both trees: current layout → `exit 1` with "most likely corrupt"; patched layout → found.

Not tested: `run.sh` end to end (needs the full builder environment; no zsh here). The changed lines are inspection-only, though the `case`/`local` constructs mirror the `mips*` case two lines above.

## Scope

`validator` and `snclaim` call the same function but only target darwin/linux, so `provider` is the only affected artifact. Other windows producers on the release path are clean — `urnetwork/windows:build-sdk.ps1` names its `-o` output `.dll` explicitly, and `proxy/socks/Makefile` uses the directory form and correctly emits `socks.exe` in the same release run.

Left out of this PR:

- `sn/miner/Makefile` has the identical bug (`-o build/windows/<arch>/miner`). Not on the release path — `run.sh` never invokes any sn Makefile — but it produces the same broken output. PR: urfoundation/sn#3.
- The `cd connect/provider && go build` block in the provider docs is stale beyond this fix: it points at a directory deleted in connect@3b6b151, and its bare `go build` never produced the `build/<os>/<arch>/` layout it claims to. It also lists the outputs extensionless. Source is `docs/provider/README.md:140-149`, with generated copies in `docs/llms-full.txt` and `urnetwork/web`. Worth a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
